### PR TITLE
Enable Apple amd64 builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,12 +4,12 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
-          
+
 jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest,windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -20,7 +20,7 @@ jobs:
             export LENS_VERSION=$(cat version)
             echo "LENS_VERSION=$LENS_VERSION" >> $GITHUB_ENV
         shell: bash
-      - uses: actions/setup-node@v3        
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.16.0
       - name: Update Lens
@@ -36,15 +36,29 @@ jobs:
           if [ "$RUNNER_OS" == "Windows" ]; then
             choco install visualstudio2019buildtools visualstudio2019-workload-vctools
           fi
-          make build
           if [ "$RUNNER_OS" == "macOS" ]; then
-                cp dist/OpenLens-${{ env.LENS_VERSION }}-latest.*.dmg releasefiles/OpenLens-${{ env.LENS_VERSION }}.dmg
-                cp dist/OpenLens-${{ env.LENS_VERSION }}-latest.*.zip releasefiles/OpenLens-${{ env.LENS_VERSION }}.zip
+                env ELECTRON_BUILDER_EXTRA_ARGS="--arm64 --x64" make build
+                for file in dist/OpenLens-${{ env.LENS_VERSION }}-latest.*.dmg; do
+                    if [[ "$file" == *"arm64"* ]]; then
+                        echo cp "$file" releasefiles/OpenLens-${{ env.LENS_VERSION }}-arm64.dmg
+                    else
+                        echo cp "$file" releasefiles/OpenLens-${{ env.LENS_VERSION }}.dmg
+                    fi
+                done
+                for file in dist/OpenLens-${{ env.LENS_VERSION }}-latest.*.zip; do
+                    if [[ "$file" == *"arm64"* ]]; then
+                        cp "$file" releasefiles/OpenLens-${{ env.LENS_VERSION }}-arm64.zip
+                    else
+                        cp "$file" releasefiles/OpenLens-${{ env.LENS_VERSION }}.zip
+                    fi
+                done
           elif [ "$RUNNER_OS" == "Linux" ]; then
+                make build
                 cp dist/OpenLens-${{ env.LENS_VERSION }}-latest.*.x86_64.AppImage releasefiles/OpenLens-${{ env.LENS_VERSION }}.AppImage
                 cp dist/OpenLens-${{ env.LENS_VERSION }}-latest.*.amd64.deb releasefiles/OpenLens-${{ env.LENS_VERSION }}.deb
                 cp dist/OpenLens-${{ env.LENS_VERSION }}-latest.*.x86_64.rpm releasefiles/OpenLens-${{ env.LENS_VERSION }}.rpm
           else
+                make build
                 cp dist/OpenLens*.exe releasefiles/OpenLens-${{ env.LENS_VERSION }}.exe
           fi
         shell: bash
@@ -63,11 +77,11 @@ jobs:
         with:
           tag_name: v${{ env.LENS_VERSION }}
           files: | 
-              lens/releasefiles/OpenLens-${{ env.LENS_VERSION }}.dmg
+              lens/releasefiles/OpenLens-${{ env.LENS_VERSION }}-*.dmg
               lens/releasefiles/OpenLens-${{ env.LENS_VERSION }}.AppImage
               lens/releasefiles/OpenLens-${{ env.LENS_VERSION }}.deb
               lens/releasefiles/OpenLens-${{ env.LENS_VERSION }}.rpm
-              lens/releasefiles/OpenLens-${{ env.LENS_VERSION }}.zip
+              lens/releasefiles/OpenLens-${{ env.LENS_VERSION }}-*.zip
               lens/releasefiles/OpenLens-${{ env.LENS_VERSION }}.exe
               lens/releasefiles/OpenLens-${{ env.LENS_VERSION }}.*.sha256
       - name: Latest


### PR DESCRIPTION
This is an alternative to #14 

I verified this by running `ELECTRON_BUILDER_EXTRA_ARGS="--arm64 --x64" make clean build` on my intel Mac and copied the arm64 build to my M1 Mac. On M1, I tested OpenLens with a local minikube.

Building x64 and arm64 on together is required to generate a bundled `latest-mac.yaml` file. (https://github.com/electron-userland/electron-builder/issues/5592#issuecomment-770057575)

Build times are still fine: 

```
yarn run electron-builder --publish onTag --arm64 --x64
yarn run v1.22.19
$ /Users/jkr/Downloads/lens/node_modules/.bin/electron-builder --publish onTag --arm64 --x64
  • electron-builder  version=23.1.0 os=21.6.0
  • loaded configuration  file=package.json ("build" field)
  • writing effective config  file=dist/builder-effective-config.yaml
  • rebuilding native dependencies  dependencies=node-pty@0.10.1 platform=darwin arch=x64
  • rebuilding native dependency  name=node-pty version=0.10.1
  • packaging       platform=darwin arch=x64 electron=15.5.7 appOutDir=dist/mac
  • file source doesn't exist  from=/Users/jkr/Downloads/lens/locales
  • skipped macOS application code signing  reason=cannot find valid "Developer ID Application" identity or custom non-Apple code signing certificate, it could cause some undefined behaviour, e.g. macOS localized description not visible, see https://electron.build/code-signing allIdentities=  1) DB18FD789312661372C9CD713689A5EEBBFAF8A4 "com.apple.systemdefault" (CSSMERR_TP_NOT_TRUSTED)
  2) D98B80C74D4D042D6524FE4413373962E675B79E "com.apple.kerberos.kdc" (CSSMERR_TP_NOT_TRUSTED)
     2 identities found
                                                Valid identities only
     0 valid identities found
  • building        target=macOS zip arch=x64 file=dist/OpenLens-6.0.0-latest.1659257326349.1659267010061-mac.zip
  • building        target=DMG arch=x64 file=dist/OpenLens-6.0.0-latest.1659257326349.1659267010061.dmg
  • rebuilding native dependencies  dependencies=node-pty@0.10.1 platform=darwin arch=arm64
  • rebuilding native dependency  name=node-pty version=0.10.1
  • packaging       platform=darwin arch=arm64 electron=15.5.7 appOutDir=dist/mac-arm64
  • building block map  blockMapFile=dist/OpenLens-6.0.0-latest.1659257326349.1659267010061.dmg.blockmap
  • file source doesn't exist  from=/Users/jkr/Downloads/lens/locales
  • skipped macOS application code signing  reason=cannot find valid "Developer ID Application" identity or custom non-Apple code signing certificate, it could cause some undefined behaviour, e.g. macOS localized description not visible, see https://electron.build/code-signing allIdentities=  1) DB18FD789312661372C9CD713689A5EEBBFAF8A4 "com.apple.systemdefault" (CSSMERR_TP_NOT_TRUSTED)
  2) D98B80C74D4D042D6524FE4413373962E675B79E "com.apple.kerberos.kdc" (CSSMERR_TP_NOT_TRUSTED)
     2 identities found
                                                Valid identities only
     0 valid identities found
  • building        target=macOS zip arch=arm64 file=dist/OpenLens-6.0.0-latest.1659257326349.1659267010061-arm64-mac.zip
  • building        target=DMG arch=arm64 file=dist/OpenLens-6.0.0-latest.1659257326349.1659267010061-arm64.dmg

  • building block map  blockMapFile=dist/OpenLens-6.0.0-latest.1659257326349.1659267010061-arm64.dmg.blockmap
  • building block map  blockMapFile=dist/OpenLens-6.0.0-latest.1659257326349.1659267010061-mac.zip.blockmap
  • building block map  blockMapFile=dist/OpenLens-6.0.0-latest.1659257326349.1659267010061-arm64-mac.zip.blockmap
✨  Done in 198.87s.
```

Example:

```yaml
# cat latest-mac.yml
version: 6.0.0-latest.1659257326349.1659267010061
files:
  - url: OpenLens-6.0.0-latest.1659257326349.1659267010061-mac.zip
    sha512: W9vnFd8umiv9w3QaMunTxYYaxfilBntrsNh9hbPWuL/1jmhEHQEvLOQOMn5yQuPRY+ggdgMjCZ4LjQ7GCS6JIg==
    size: 170006739
  - url: OpenLens-6.0.0-latest.1659257326349.1659267010061-arm64-mac.zip
    sha512: EbwfQtJzznIfewKUWn8K387zCIdpKWr3ARDW6vgwvumEWkJWrBw5csNKx2c2P/XFFWxpGMYECT1nckRW1T/59Q==
    size: 170673335
  - url: OpenLens-6.0.0-latest.1659257326349.1659267010061.dmg
    sha512: TeczNljQ0nqd21oWyipTKYhb6Btjr325ZPkaY1fccIkKPtSfxtMVE/EJGdF7DEaRnTIsFpWUNwTmLnL95qY4Ig==
    size: 176265768
  - url: OpenLens-6.0.0-latest.1659257326349.1659267010061-arm64.dmg
    sha512: GvsM/7MzxQiXnjJW/4JHE4l6WuypegM1pz16W/v3Tfna2IqUyYObC3kQ5/jkfJ1nbh2nMP5F2DhsJlZyDqSfnA==
    size: 177257350
path: OpenLens-6.0.0-latest.1659257326349.1659267010061-mac.zip
sha512: W9vnFd8umiv9w3QaMunTxYYaxfilBntrsNh9hbPWuL/1jmhEHQEvLOQOMn5yQuPRY+ggdgMjCZ4LjQ7GCS6JIg==
releaseDate: '2022-07-31T11:38:40.731Z'
```

Closes #3
Closes #14 