### PR TITLE
Fix issue with MacOS ARM versioned releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,14 +49,14 @@ jobs:
             fi
           
             env ELECTRON_BUILDER_EXTRA_ARGS="--arm64 --x64 --config.dmg.sign=false" make build
-            for file in dist/OpenLens-${{ env.LENS_VERSION }}.dmg; do
+            for file in dist/OpenLens-${{ env.LENS_VERSION }}*.dmg; do
               if [[ "$file" == *"arm64"* ]]; then
                 cp "$file" releasefiles/OpenLens-${{ env.LENS_VERSION }}-arm64.dmg
               else
                 cp "$file" releasefiles/OpenLens-${{ env.LENS_VERSION }}.dmg
               fi
             done
-            for file in dist/OpenLens-${{ env.LENS_VERSION }}-mac.zip; do
+            for file in dist/OpenLens-${{ env.LENS_VERSION }}*-mac.zip; do
               if [[ "$file" == *"arm64"* ]]; then
                 cp "$file" releasefiles/OpenLens-${{ env.LENS_VERSION }}-arm64.zip
               else

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 360
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v2.5.0
       - name: Export version to variable
         run: |
             export LENS_VERSION=$(cat version)
@@ -72,8 +72,6 @@ jobs:
             cp dist/OpenLens-${{ env.LENS_VERSION }}.arm64.deb releasefiles/OpenLens-${{ env.LENS_VERSION }}.arm64.deb
             cp dist/OpenLens-${{ env.LENS_VERSION }}.aarch64.rpm releasefiles/OpenLens-${{ env.LENS_VERSION }}.arm64.rpm
           else
-            unset WIN_CSC_LINK
-            unset WIN_CSC_KEY_PASSWORD
             make build
             cp dist/OpenLens*.exe releasefiles/OpenLens-${{ env.LENS_VERSION }}.exe
           fi
@@ -87,6 +85,8 @@ jobs:
           CSC_KEY_PASSWORD: ${{ runner.os == 'macos' && secrets.CSC_KEY_PASSWORD || secrets.CSC_KEY_PASSWORD_WIN}}
           CSC_LINK_WIN: ${{ secrets.CSC_LINK_WIN }}
           CSC_KEY_PASSWORD_WIN: ${{ secrets.CSC_KEY_PASSWORD_WIN }}
+          WIN_CSC_LINK: ${{ secrets.CSC_LINK_WIN }}
+          WIN_CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD_WIN }}
           CSC_FOR_PULL_REQUEST: true
 
       - name: Calculate SHA256 checksum

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,8 +85,8 @@ jobs:
           CSC_KEY_PASSWORD: ${{ runner.os == 'macos' && secrets.CSC_KEY_PASSWORD || secrets.CSC_KEY_PASSWORD_WIN}}
           CSC_LINK_WIN: ${{ secrets.CSC_LINK_WIN }}
           CSC_KEY_PASSWORD_WIN: ${{ secrets.CSC_KEY_PASSWORD_WIN }}
-          WIN_CSC_LINK: ${{ secrets.CSC_LINK_WIN }}
-          WIN_CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD_WIN }}
+          WIN_CSC_LINK: ""
+          WIN_CSC_KEY_PASSWORD: ""
           CSC_FOR_PULL_REQUEST: true
 
       - name: Calculate SHA256 checksum

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,8 @@ jobs:
             cp dist/OpenLens-${{ env.LENS_VERSION }}.arm64.deb releasefiles/OpenLens-${{ env.LENS_VERSION }}.arm64.deb
             cp dist/OpenLens-${{ env.LENS_VERSION }}.aarch64.rpm releasefiles/OpenLens-${{ env.LENS_VERSION }}.arm64.rpm
           else
+            unset WIN_CSC_LINK
+            unset WIN_CSC_KEY_PASSWORD
             make build
             cp dist/OpenLens*.exe releasefiles/OpenLens-${{ env.LENS_VERSION }}.exe
           fi


### PR DESCRIPTION
There is an issue that the ARM versions of the MacOS builds are not being added to the version tagged releases e.g. v6.2.0 which this PR fixes.