### PR TITLE
Update hack script to adapt monorepo structure from upstream

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,9 +35,8 @@ jobs:
           fetch-depth: 1
       - name: Patch Upstream Lens
         run: |
-          cp update.js lens/update.js
-          cd lens
           node update.js
+          cd lens
       - name: Build Lens
         run: |
           mkdir releasefiles
@@ -53,15 +52,15 @@ jobs:
               unset CSC_KEY_PASSWORD
             fi
             yarn
-            env ELECTRON_BUILDER_EXTRA_ARGS="--arm64 --x64 --config.dmg.sign=false" yarn run build
-            for file in dist/OpenLens-${{ env.LENS_VERSION }}.dmg; do
+            env ELECTRON_BUILDER_EXTRA_ARGS="--arm64 --x64 --config.dmg.sign=false" yarn run build:app
+            for file in packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.dmg; do
               if [[ "$file" == *"arm64"* ]]; then
                 cp "$file" releasefiles/OpenLens-${{ env.LENS_VERSION }}-arm64.dmg
               else
                 cp "$file" releasefiles/OpenLens-${{ env.LENS_VERSION }}.dmg
               fi
             done
-            for file in dist/OpenLens-${{ env.LENS_VERSION }}-mac.zip; do
+            for file in packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}-mac.zip; do
               if [[ "$file" == *"arm64"* ]]; then
                 cp "$file" releasefiles/OpenLens-${{ env.LENS_VERSION }}-arm64.zip
               else
@@ -70,18 +69,18 @@ jobs:
             done
           elif [ "$RUNNER_OS" == "Linux" ]; then
             yarn
-            env ELECTRON_BUILDER_EXTRA_ARGS="--x64 --arm64" yarn run build
-            cp dist/OpenLens-${{ env.LENS_VERSION }}.x86_64.AppImage releasefiles/OpenLens-${{ env.LENS_VERSION }}.AppImage
-            cp dist/OpenLens-${{ env.LENS_VERSION }}.amd64.deb releasefiles/OpenLens-${{ env.LENS_VERSION }}.deb
-            cp dist/OpenLens-${{ env.LENS_VERSION }}.x86_64.rpm releasefiles/OpenLens-${{ env.LENS_VERSION }}.rpm
-            cp dist/OpenLens-${{ env.LENS_VERSION }}.arm64.AppImage releasefiles/OpenLens-${{ env.LENS_VERSION }}.arm64.AppImage
-            cp dist/OpenLens-${{ env.LENS_VERSION }}.arm64.deb releasefiles/OpenLens-${{ env.LENS_VERSION }}.arm64.deb
-            cp dist/OpenLens-${{ env.LENS_VERSION }}.aarch64.rpm releasefiles/OpenLens-${{ env.LENS_VERSION }}.arm64.rpm
+            env ELECTRON_BUILDER_EXTRA_ARGS="--x64 --arm64" yarn run build:app
+            cp packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.x86_64.AppImage releasefiles/OpenLens-${{ env.LENS_VERSION }}.AppImage
+            cp packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.amd64.deb releasefiles/OpenLens-${{ env.LENS_VERSION }}.deb
+            cp packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.x86_64.rpm releasefiles/OpenLens-${{ env.LENS_VERSION }}.rpm
+            cp packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.arm64.AppImage releasefiles/OpenLens-${{ env.LENS_VERSION }}.arm64.AppImage
+            cp packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.arm64.deb releasefiles/OpenLens-${{ env.LENS_VERSION }}.arm64.deb
+            cp packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.aarch64.rpm releasefiles/OpenLens-${{ env.LENS_VERSION }}.arm64.rpm
           else
             yarn
-            yarn run build
-            cp dist/OpenLens*.exe releasefiles/OpenLens-${{ env.LENS_VERSION }}.exe
-            cp dist/OpenLens*.exe dist/OpenLens-${{ env.LENS_VERSION }}.exe
+            yarn run build:app
+            cp packages/open-lens/dist/OpenLens*.exe releasefiles/OpenLens-${{ env.LENS_VERSION }}.exe
+            cp packages/open-lens/dist/OpenLens*.exe packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.exe
           fi
         shell: bash
         working-directory: lens
@@ -113,13 +112,13 @@ jobs:
           name: OpenLens-${{ matrix.os }}
           retention-days: 5
           path: |
-            lens/dist/OpenLens-${{ env.LENS_VERSION }}*.dmg
-            lens/dist/OpenLens-${{ env.LENS_VERSION }}*.AppImage
-            lens/dist/OpenLens-${{ env.LENS_VERSION }}*.deb
-            lens/dist/OpenLens-${{ env.LENS_VERSION }}*.rpm
-            lens/dist/OpenLens-${{ env.LENS_VERSION }}*.zip
-            lens/dist/OpenLens-${{ env.LENS_VERSION }}.exe
-            lens/dist/OpenLens-${{ env.LENS_VERSION }}*.sha256
+            lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.dmg
+            lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.AppImage
+            lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.deb
+            lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.rpm
+            lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.zip
+            lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.exe
+            lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.sha256
 
       - name: Generate Changelog
         run: curl -s https://api.github.com/repos/lensapp/lens/releases/latest | jq -r 'select(.prerelease == false) | .body[0:]' > ${{ github.workspace }}-CHANGELOG.txt
@@ -130,23 +129,23 @@ jobs:
           tag_name: v${{ env.LENS_VERSION }}
           body_path: ${{ github.workspace }}-CHANGELOG.txt
           files: | 
-            lens/dist/OpenLens-${{ env.LENS_VERSION }}*.dmg
-            lens/dist/OpenLens-${{ env.LENS_VERSION }}*.AppImage
-            lens/dist/OpenLens-${{ env.LENS_VERSION }}*.deb
-            lens/dist/OpenLens-${{ env.LENS_VERSION }}*.rpm
-            lens/dist/OpenLens-${{ env.LENS_VERSION }}*.zip
-            lens/dist/OpenLens-${{ env.LENS_VERSION }}.exe
-            lens/dist/OpenLens-${{ env.LENS_VERSION }}*.sha256
+            lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.dmg
+            lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.AppImage
+            lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.deb
+            lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.rpm
+            lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.zip
+            lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.exe
+            lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.sha256
       - name: Latest
         uses: softprops/action-gh-release@v0.1.14
         if: github.ref == 'refs/heads/main'
         with:
           tag_name: Latest
           files: | 
-            lens/dist/OpenLens-${{ env.LENS_VERSION }}*.dmg
-            lens/dist/OpenLens-${{ env.LENS_VERSION }}*.AppImage
-            lens/dist/OpenLens-${{ env.LENS_VERSION }}*.deb
-            lens/dist/OpenLens-${{ env.LENS_VERSION }}*.rpm
-            lens/dist/OpenLens-${{ env.LENS_VERSION }}*.zip
-            lens/dist/OpenLens.Setup.${{ env.LENS_VERSION }}.exe
+            lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.dmg
+            lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.AppImage
+            lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.deb
+            lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.rpm
+            lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.zip
+            lens/packages/open-lens/dist/OpenLens.Setup.${{ env.LENS_VERSION }}.exe
             lens/dist/lates*.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 360
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3.2.0
+      - name: Checkout OpenLens
+        uses: actions/checkout@v3
       - name: Export version to variable
         run: |
             export LENS_VERSION=$(cat version)
@@ -26,12 +26,17 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.16.0
-      - name: Update Lens
+      - name: Checkout Upstream Lens
+        uses: actions/checkout@v3
+        with:
+          repository: lensapp/lens
+          path: lens
+          ref: v${{ env.LENS_VERSION }}
+          fetch-depth: 1
+      - name: Patch Upstream Lens
         run: |
-          git clone https://github.com/lensapp/lens.git
           cp update.js lens/update.js
           cd lens
-          git checkout v${{ env.LENS_VERSION }}
           node update.js
       - name: Build Lens
         run: |
@@ -47,8 +52,8 @@ jobs:
             if [ "${CSC_KEY_PASSWORD}" = "" ]; then
               unset CSC_KEY_PASSWORD
             fi
-            npm install
-            env ELECTRON_BUILDER_EXTRA_ARGS="--arm64 --x64 --config.dmg.sign=false" npm run build
+            yarn
+            env ELECTRON_BUILDER_EXTRA_ARGS="--arm64 --x64 --config.dmg.sign=false" yarn run build
             for file in dist/OpenLens-${{ env.LENS_VERSION }}.dmg; do
               if [[ "$file" == *"arm64"* ]]; then
                 cp "$file" releasefiles/OpenLens-${{ env.LENS_VERSION }}-arm64.dmg
@@ -64,8 +69,8 @@ jobs:
               fi
             done
           elif [ "$RUNNER_OS" == "Linux" ]; then
-            npm install
-            env ELECTRON_BUILDER_EXTRA_ARGS="--x64 --arm64" npm run build
+            yarn
+            env ELECTRON_BUILDER_EXTRA_ARGS="--x64 --arm64" yarn run build
             cp dist/OpenLens-${{ env.LENS_VERSION }}.x86_64.AppImage releasefiles/OpenLens-${{ env.LENS_VERSION }}.AppImage
             cp dist/OpenLens-${{ env.LENS_VERSION }}.amd64.deb releasefiles/OpenLens-${{ env.LENS_VERSION }}.deb
             cp dist/OpenLens-${{ env.LENS_VERSION }}.x86_64.rpm releasefiles/OpenLens-${{ env.LENS_VERSION }}.rpm
@@ -73,8 +78,8 @@ jobs:
             cp dist/OpenLens-${{ env.LENS_VERSION }}.arm64.deb releasefiles/OpenLens-${{ env.LENS_VERSION }}.arm64.deb
             cp dist/OpenLens-${{ env.LENS_VERSION }}.aarch64.rpm releasefiles/OpenLens-${{ env.LENS_VERSION }}.arm64.rpm
           else
-            npm install
-            npm run build
+            yarn
+            yarn run build
             cp dist/OpenLens*.exe releasefiles/OpenLens-${{ env.LENS_VERSION }}.exe
             cp dist/OpenLens*.exe dist/OpenLens-${{ env.LENS_VERSION }}.exe
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
             fi
             yarn
             yarn run build
-            env ELECTRON_BUILDER_EXTRA_ARGS="--arm64 --x64 --config.dmg.sign=false" yarn run build:app
+            yarn run build:app
             for file in packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.dmg; do
               if [[ "$file" == *"arm64"* ]]; then
                 cp "$file" releasefiles/OpenLens-${{ env.LENS_VERSION }}-arm64.dmg
@@ -71,7 +71,8 @@ jobs:
           elif [ "$RUNNER_OS" == "Linux" ]; then
             yarn
             yarn run build
-            env ELECTRON_BUILDER_EXTRA_ARGS="--x64 --arm64" yarn run build:app
+            yarn run build:app
+            ls packages/open-lens/dist/
             cp packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.x86_64.AppImage releasefiles/OpenLens-${{ env.LENS_VERSION }}.AppImage
             cp packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.amd64.deb releasefiles/OpenLens-${{ env.LENS_VERSION }}.deb
             cp packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.x86_64.rpm releasefiles/OpenLens-${{ env.LENS_VERSION }}.rpm

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,4 +151,4 @@ jobs:
             lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.rpm
             lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.zip
             lens/packages/open-lens/dist/OpenLens.Setup.${{ env.LENS_VERSION }}.exe
-            lens/dist/lates*.yml
+            lens/packages/open-lens/dist/lates*.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
             for filename in OpenLens-${{ env.LENS_VERSION }}*; do shasum -a 256 ${filename} | tee ${filename}.sha256 ; done
           fi
         shell: bash
-        working-directory: lens/dist
+        working-directory: lens/packages/open-lens/dist
 
       - uses: actions/upload-artifact@v3
         if: github.ref != 'refs/heads/main'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         shell: bash
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.16.0
+          node-version: 16.19.0
       - name: Checkout Upstream Lens
         uses: actions/checkout@v3
         with:
@@ -52,6 +52,7 @@ jobs:
               unset CSC_KEY_PASSWORD
             fi
             yarn
+            yarn run build
             env ELECTRON_BUILDER_EXTRA_ARGS="--arm64 --x64 --config.dmg.sign=false" yarn run build:app
             for file in packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.dmg; do
               if [[ "$file" == *"arm64"* ]]; then
@@ -69,6 +70,7 @@ jobs:
             done
           elif [ "$RUNNER_OS" == "Linux" ]; then
             yarn
+            yarn run build
             env ELECTRON_BUILDER_EXTRA_ARGS="--x64 --arm64" yarn run build:app
             cp packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.x86_64.AppImage releasefiles/OpenLens-${{ env.LENS_VERSION }}.AppImage
             cp packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.amd64.deb releasefiles/OpenLens-${{ env.LENS_VERSION }}.deb
@@ -78,6 +80,7 @@ jobs:
             cp packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.aarch64.rpm releasefiles/OpenLens-${{ env.LENS_VERSION }}.arm64.rpm
           else
             yarn
+            yarn run build
             yarn run build:app
             cp packages/open-lens/dist/OpenLens*.exe releasefiles/OpenLens-${{ env.LENS_VERSION }}.exe
             cp packages/open-lens/dist/OpenLens*.exe packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,6 @@ jobs:
             yarn
             yarn run build
             yarn run build:app
-            ls packages/open-lens/dist/
             cp packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.x86_64.AppImage releasefiles/OpenLens-${{ env.LENS_VERSION }}.AppImage
             cp packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.amd64.deb releasefiles/OpenLens-${{ env.LENS_VERSION }}.deb
             cp packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.x86_64.rpm releasefiles/OpenLens-${{ env.LENS_VERSION }}.rpm

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Generate Changelog
         run: curl -s https://api.github.com/repos/lensapp/lens/releases/latest | jq -r 'select(.prerelease == false) | .body[0:]' > ${{ github.workspace }}-CHANGELOG.txt
       - name: Release
-        uses: softprops/action-gh-release@v0.1.14
+        uses: softprops/action-gh-release@v0.1.15
         if: github.ref == 'refs/heads/main'
         with:
           tag_name: v${{ env.LENS_VERSION }}
@@ -140,7 +140,7 @@ jobs:
             lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}.exe
             lens/packages/open-lens/dist/OpenLens-${{ env.LENS_VERSION }}*.sha256
       - name: Latest
-        uses: softprops/action-gh-release@v0.1.14
+        uses: softprops/action-gh-release@v0.1.15
         if: github.ref == 'refs/heads/main'
         with:
           tag_name: Latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,6 @@ jobs:
       - name: Patch Upstream Lens
         run: |
           node update.js
-          cd lens
       - name: Build Lens
         run: |
           mkdir releasefiles

--- a/update.js
+++ b/update.js
@@ -9,4 +9,4 @@ packagejson.build.publish = [{
 
 packagejson.build.win.artifactName = "OpenLens.Setup.${version}.${ext}";
 
-fs.writeFileSync('package.json', JSON.stringify(packagejson));
+fs.writeFileSync('./packages/open-lens/package.json', JSON.stringify(packagejson));

--- a/update.js
+++ b/update.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 
-var packagejson = require('./packages/open-lens/package.json');
+var packagejson = require('./lens/packages/open-lens/package.json');
 
 packagejson.build.publish = [{
     url: "https://github.com/MuhammedKalkan/OpenLens/releases/download/Latest",
@@ -9,4 +9,4 @@ packagejson.build.publish = [{
 
 packagejson.build.win.artifactName = "OpenLens.Setup.${version}.${ext}";
 
-fs.writeFileSync('./packages/open-lens/package.json', JSON.stringify(packagejson));
+fs.writeFileSync('./lens/packages/open-lens/package.json', JSON.stringify(packagejson));

--- a/update.js
+++ b/update.js
@@ -9,4 +9,9 @@ packagejson.build.publish = [{
 
 packagejson.build.win.artifactName = "OpenLens.Setup.${version}.${ext}";
 
+if (process.platform != "win32") {
+    // build both x86_64 and arm64 for Linux and Darwin
+    packagejson.scripts['build:app'] = "electron-builder --publish onTag --x64 --arm64";
+}
+
 fs.writeFileSync('./lens/packages/open-lens/package.json', JSON.stringify(packagejson));


### PR DESCRIPTION
Related upstream change https://github.com/lensapp/lens/pull/6907

 - [x] Update `update.js` to support multi-arch build on macos and Linux
 - [x] Adapt dir change
 - [x] Polish GitHub Actions: use `yarn`, use shallow clone, update `node.js`, etc.

Compilation and shasum check seem to be all right now. The release step failed due to restricted GITHUB_TOKEN settings while for windows some other tokens are needed.