### PR TITLE
Make it generate tar.gz file for linux 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
             sudo apt update
             sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu -y
           
-            npx nx run open-lens:build:app --x64 --arm64
+            npx nx run open-lens:build:app --linux rpm deb tar.gz --x64 --arm64
             find . -name '*pty.node' -print0 | xargs -0 file
           else
             npx nx run open-lens:build:app --x64 --arm64

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Download and install appropriate package
 (`.rpm`, `.deb` or `.AppImage`)
 and install based on available package manager.
 
+Or download the tarball binary `.tar.gz` file and expand it to `/opt` for example.
+
 ### Windows
 
 #### Scoop


### PR DESCRIPTION
I would like to generate a linux tarball alongside the .deb, .rmp and .appimage formats to be able to use it in an [asdf-openlens package](https://github.com/rsvalerio/asdf-openlens) I'm working on.

Thanks in advance.